### PR TITLE
adding offline_access scope to receive refresh tokens

### DIFF
--- a/src/app/auth/auth-config.module.ts
+++ b/src/app/auth/auth-config.module.ts
@@ -18,7 +18,7 @@ import {authConfig} from "../../../../../wisdom.config";
       renewTimeBeforeTokenExpiresInSeconds: 30,
       autoUserInfo: true,
       renewUserInfoAfterTokenRenew: true,
-      scope: "openid profile email goauthentik.io/api"
+      scope: "openid profile email offline_access goauthentik.io/api"
     }, authConfig)
   }), WisdomModule, TranslateModule],
   exports: [AuthModule],


### PR DESCRIPTION
Due to changes in the IDP used for WISdoM, the IDP now requires using the `offline_access` scope to receive refresh tokens. Since the refresh token is used to access the IDP's API this should fix any forbidden errors